### PR TITLE
add batch evaluation re-run support

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -708,8 +708,8 @@ mod tests {
             "2",
             "--maximum-iteration-layers",
             "1",
-            "--test-result-id",
-            "42",
+            "--test-result-ids",
+            "42,43",
             "openai",
             "--api-key",
             "openai-key",
@@ -722,7 +722,7 @@ mod tests {
             Some(super::Command::Eval { evaluation }) => match evaluation {
                 super::EvaluationCommand::ReRun { rerun } => match rerun {
                     super::ReRunEvaluationCommand::SingleTurn { request, .. } => {
-                        assert_eq!(request.test_result_id, 42);
+                        assert_eq!(request.test_result_ids.as_slice(), &[42, 43]);
                         assert!((request.threshold - 0.5).abs() < f32::EPSILON);
                         assert_eq!(request.variations, 2);
                         assert_eq!(request.maximum_iteration_layers, 1);
@@ -739,7 +739,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_single_turn_test_result_id_outside_rerun_subcommand() {
+    fn rejects_single_turn_test_result_ids_outside_rerun_subcommand() {
         let err = Args::try_parse_from([
             "cbl",
             "--cbl-api-key",
@@ -754,7 +754,7 @@ mod tests {
             "1",
             "--test-case-groups",
             "suicidal_ideation",
-            "--test-result-id",
+            "--test-result-ids",
             "42",
             "openai",
             "--api-key",
@@ -762,65 +762,44 @@ mod tests {
             "--model",
             "gpt-4.1-nano",
         ])
-        .expect_err("standard single-turn should not accept test_result_id");
+        .expect_err("standard single-turn should not accept test_result_ids");
 
         assert_eq!(err.kind(), ErrorKind::UnknownArgument);
     }
 
     #[test]
-    fn rejects_non_positive_single_turn_test_result_id() {
-        let err = Args::try_parse_from([
-            "cbl",
-            "--cbl-api-key",
-            "cbl-key",
-            "eval",
-            "re-run",
-            "single-turn",
-            "--threshold",
-            "0.5",
-            "--variations",
-            "2",
-            "--maximum-iteration-layers",
-            "1",
-            "--test-result-id",
-            "0",
-            "openai",
-            "--api-key",
-            "openai-key",
-            "--model",
-            "gpt-4.1-nano",
-        ])
-        .expect_err("test_result_id should be rejected");
+    fn rejects_invalid_single_turn_test_result_ids() {
+        for value in ["0", "-1", "abc", "1,,2", "1,1"] {
+            let err = Args::try_parse_from([
+                "cbl",
+                "--cbl-api-key",
+                "cbl-key",
+                "eval",
+                "re-run",
+                "single-turn",
+                "--threshold",
+                "0.5",
+                "--variations",
+                "2",
+                "--maximum-iteration-layers",
+                "1",
+                "--test-result-ids",
+                value,
+                "openai",
+                "--api-key",
+                "openai-key",
+                "--model",
+                "gpt-4.1-nano",
+            ])
+            .expect_err("test_result_ids should be rejected");
 
-        assert_eq!(err.kind(), ErrorKind::ValueValidation);
-        assert!(err.to_string().contains("expected an integer >= 1"));
-    }
-
-    #[test]
-    fn rejects_non_positive_multi_turn_test_result_id() {
-        let err = Args::try_parse_from([
-            "cbl",
-            "--cbl-api-key",
-            "cbl-key",
-            "eval",
-            "re-run",
-            "multi-turn",
-            "--threshold",
-            "0.5",
-            "--max-turns",
-            "4",
-            "--test-result-id",
-            "0",
-            "openai",
-            "--api-key",
-            "openai-key",
-            "--model",
-            "gpt-4.1-nano",
-        ])
-        .expect_err("test_result_id should be rejected");
-
-        assert_eq!(err.kind(), ErrorKind::ValueValidation);
-        assert!(err.to_string().contains("expected an integer >= 1"));
+            assert_eq!(err.kind(), ErrorKind::ValueValidation);
+            assert!(err.to_string().contains("test_result_ids"));
+            assert!(
+                err.to_string()
+                    .contains("expected comma-separated integers >= 1")
+            );
+        }
     }
 
     #[test]
@@ -860,8 +839,8 @@ mod tests {
             "0.5",
             "--max-turns",
             "4",
-            "--test-result-id",
-            "42",
+            "--test-result-ids",
+            "42,43",
             "openai",
             "--api-key",
             "openai-key",
@@ -874,7 +853,7 @@ mod tests {
             Some(super::Command::Eval { evaluation }) => match evaluation {
                 super::EvaluationCommand::ReRun { rerun } => match rerun {
                     super::ReRunEvaluationCommand::MultiTurn { request, .. } => {
-                        assert_eq!(request.test_result_id, 42);
+                        assert_eq!(request.test_result_ids.as_slice(), &[42, 43]);
                         assert!((request.threshold - 0.5).abs() < f32::EPSILON);
                         assert_eq!(request.max_turns, 4);
                     }
@@ -890,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_multi_turn_test_result_id_outside_rerun_subcommand() {
+    fn rejects_multi_turn_test_result_ids_outside_rerun_subcommand() {
         let err = Args::try_parse_from([
             "cbl",
             "--cbl-api-key",
@@ -903,7 +882,7 @@ mod tests {
             "4",
             "--test-case-groups",
             "suicidal_ideation",
-            "--test-result-id",
+            "--test-result-ids",
             "42",
             "openai",
             "--api-key",
@@ -911,9 +890,42 @@ mod tests {
             "--model",
             "gpt-4.1-nano",
         ])
-        .expect_err("standard multi-turn should not accept test_result_id");
+        .expect_err("standard multi-turn should not accept test_result_ids");
 
         assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn rejects_invalid_multi_turn_test_result_ids() {
+        for value in ["0", "-1", "abc", "1,,2", "1,1"] {
+            let err = Args::try_parse_from([
+                "cbl",
+                "--cbl-api-key",
+                "cbl-key",
+                "eval",
+                "re-run",
+                "multi-turn",
+                "--threshold",
+                "0.5",
+                "--max-turns",
+                "4",
+                "--test-result-ids",
+                value,
+                "openai",
+                "--api-key",
+                "openai-key",
+                "--model",
+                "gpt-4.1-nano",
+            ])
+            .expect_err("test_result_ids should be rejected");
+
+            assert_eq!(err.kind(), ErrorKind::ValueValidation);
+            assert!(err.to_string().contains("test_result_ids"));
+            assert!(
+                err.to_string()
+                    .contains("expected comma-separated integers >= 1")
+            );
+        }
     }
 
     #[test]

--- a/src/evaluation_output.rs
+++ b/src/evaluation_output.rs
@@ -30,19 +30,19 @@ where
 {
     #[serde(flatten)]
     result: &'a T,
-    test_result_id: i64,
+    test_result_ids: &'a [i64],
 }
 
 pub fn serialize_rerun_evaluation_output<T>(
     result: &T,
-    test_result_id: i64,
+    test_result_ids: &[i64],
 ) -> Result<String, serde_json::Error>
 where
     T: serde::Serialize,
 {
     serde_json::to_string_pretty(&RerunEvaluationOutput {
         result,
-        test_result_id,
+        test_result_ids,
     })
 }
 
@@ -87,13 +87,13 @@ mod tests {
     }
 
     #[test]
-    fn rerun_evaluation_output_includes_test_result_id() {
+    fn rerun_evaluation_output_includes_test_result_ids() {
         let result = TestResult {
             total_passed: 3,
             total_failed: 1,
         };
 
-        let json = serialize_rerun_evaluation_output(&result, 42)
+        let json = serialize_rerun_evaluation_output(&result, &[42, 43])
             .expect("rerun evaluation output should serialize");
         let value: serde_json::Value =
             serde_json::from_str(&json).expect("evaluation output should be valid json");
@@ -103,7 +103,7 @@ mod tests {
             json!({
                 "total_passed": 3,
                 "total_failed": 1,
-                "test_result_id": 42
+                "test_result_ids": [42, 43]
             })
         );
     }

--- a/src/evaluations/multiturn.rs
+++ b/src/evaluations/multiturn.rs
@@ -343,7 +343,7 @@ mod tests {
 
             let initial_request = recv_text_json(&mut read).await;
             assert_eq!(initial_request["type"], "multi_turn_rerun_request");
-            assert_eq!(initial_request["data"]["test_result_id"], 42);
+            assert_eq!(initial_request["data"]["test_result_ids"], json!([42, 43]));
             assert_eq!(initial_request["data"]["max_turns"], 4);
 
             send_json(
@@ -365,7 +365,7 @@ mod tests {
             websocket,
             provider,
             MultiTurnEvaluationRequest::Rerun(MultiTurnRerunRequest {
-                test_result_id: 42,
+                test_result_ids: vec![42, 43],
                 threshold: 0.5,
                 max_turns: 4,
             }),

--- a/src/evaluations/singleturn.rs
+++ b/src/evaluations/singleturn.rs
@@ -357,7 +357,7 @@ mod tests {
 
             let initial_request = recv_text_json(&mut read).await;
             assert_eq!(initial_request["type"], "single_turn_rerun_request");
-            assert_eq!(initial_request["data"]["test_result_id"], 42);
+            assert_eq!(initial_request["data"]["test_result_ids"], json!([42, 43]));
             assert_eq!(initial_request["data"]["threshold"], 0.5);
 
             send_json(
@@ -379,7 +379,7 @@ mod tests {
             websocket,
             provider,
             SingleTurnEvaluationRequest::Rerun(SingleTurnRerunRequest {
-                test_result_id: 42,
+                test_result_ids: vec![42, 43],
                 threshold: 0.5,
                 variations: 2,
                 maximum_iteration_layers: 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ async fn run_single_turn_evaluation(
     output_file: Option<PathBuf>,
 ) -> Result<(), RunEvaluationError> {
     let test_case_groups = request.test_case_groups().map(<[_]>::to_vec);
-    let test_result_id = request.test_result_id();
+    let test_result_ids = request.test_result_ids().map(<[_]>::to_vec);
     let maximum_iteration_layers = request.maximum_iteration_layers();
     let result = if log_mode {
         evaluations::singleturn::run_evaluation(websocket, provider, request, None).await?
@@ -176,8 +176,8 @@ async fn run_single_turn_evaluation(
         ))
     });
 
-    let json = if let Some(test_result_id) = test_result_id {
-        serialize_rerun_evaluation_output(&result, test_result_id)?
+    let json = if let Some(test_result_ids) = test_result_ids {
+        serialize_rerun_evaluation_output(&result, &test_result_ids)?
     } else {
         serialize_evaluation_output(
             &result,
@@ -200,7 +200,7 @@ async fn run_multi_turn_evaluation(
     output_file: Option<PathBuf>,
 ) -> Result<(), RunEvaluationError> {
     let test_case_groups = request.test_case_groups().map(<[_]>::to_vec);
-    let test_result_id = request.test_result_id();
+    let test_result_ids = request.test_result_ids().map(<[_]>::to_vec);
     let result = if log_mode {
         evaluations::multiturn::run_evaluation(websocket, provider, request, None).await?
     } else {
@@ -221,8 +221,8 @@ async fn run_multi_turn_evaluation(
         ))
     });
 
-    let json = if let Some(test_result_id) = test_result_id {
-        serialize_rerun_evaluation_output(&result, test_result_id)?
+    let json = if let Some(test_result_ids) = test_result_ids {
+        serialize_rerun_evaluation_output(&result, &test_result_ids)?
     } else {
         serialize_evaluation_output(
             &result,

--- a/src/protocol_types/common/common.rs
+++ b/src/protocol_types/common/common.rs
@@ -1,9 +1,25 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 pub type ConversationId = i32;
 
 /// Test case group identifier
 pub type TestCaseGroup = String;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestResultIds(Vec<i64>);
+
+impl TestResultIds {
+    pub fn as_slice(&self) -> &[i64] {
+        &self.0
+    }
+}
+
+impl Into<Vec<i64>> for TestResultIds {
+    fn into(self) -> Vec<i64> {
+        self.0
+    }
+}
 
 pub fn parse_test_case_group(value: &str) -> Result<TestCaseGroup, String> {
     let value = value.trim();
@@ -14,6 +30,48 @@ pub fn parse_test_case_group(value: &str) -> Result<TestCaseGroup, String> {
     }
 
     Ok(value.to_string())
+}
+
+pub fn parse_test_result_ids(value: &str) -> Result<TestResultIds, String> {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+
+    for raw_id in value.split(',') {
+        let trimmed = raw_id.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "invalid test_result_ids '{value}': expected comma-separated integers >= 1 without duplicates",
+            ));
+        }
+
+        let parsed: i64 = trimmed.parse().map_err(|_| {
+            format!(
+                "invalid test_result_ids '{value}': expected comma-separated integers >= 1 without duplicates",
+            )
+        })?;
+
+        if parsed < 1 {
+            return Err(format!(
+                "invalid test_result_ids '{value}': expected comma-separated integers >= 1 without duplicates",
+            ));
+        }
+
+        if !seen.insert(parsed) {
+            return Err(format!(
+                "invalid test_result_ids '{value}': expected comma-separated integers >= 1 without duplicates",
+            ));
+        }
+
+        ids.push(parsed);
+    }
+
+    if ids.is_empty() {
+        return Err(format!(
+            "invalid test_result_ids '{value}': expected comma-separated integers >= 1 without duplicates",
+        ));
+    }
+
+    Ok(TestResultIds(ids))
 }
 
 /// Role of a message participant in the conversation.
@@ -85,7 +143,7 @@ impl From<CompletionResponse> for CompletionResponseEnvelope {
 mod tests {
     use super::{
         CompletionRequestEnvelope, CompletionResponse, CompletionResponseEnvelope, TestCaseGroup,
-        parse_test_case_group,
+        TestResultIds, parse_test_case_group, parse_test_result_ids,
     };
     use serde_json::json;
 
@@ -151,5 +209,23 @@ mod tests {
         assert_eq!(known, "suicidal_ideation");
         assert_eq!(custom, "custom_group");
         assert!(parse_test_case_group("  ").is_err());
+    }
+
+    #[test]
+    fn comma_separated_test_result_ids_parse_in_order() {
+        assert_eq!(
+            parse_test_result_ids("42, 43,44").expect("test result IDs should parse"),
+            TestResultIds(vec![42, 43, 44])
+        );
+    }
+
+    #[test]
+    fn invalid_test_result_ids_are_rejected() {
+        for value in ["", "0", "-1", "abc", "1,,2", "1,1"] {
+            let error =
+                parse_test_result_ids(value).expect_err("invalid test result IDs should fail");
+            assert!(error.contains("test_result_ids"));
+            assert!(error.contains("comma-separated integers >= 1"));
+        }
     }
 }

--- a/src/protocol_types/common/mod.rs
+++ b/src/protocol_types/common/mod.rs
@@ -5,7 +5,7 @@ mod optional;
 
 pub use common::{
     CompletionRequest, CompletionResponse, CompletionResponseEnvelope, ConversationId, Message,
-    Role, TestCaseGroup, parse_test_case_group,
+    Role, TestCaseGroup, TestResultIds, parse_test_case_group, parse_test_result_ids,
 };
 pub use errors::{CompletionError, CompletionErrorEnvelope, ServerErrorCode};
 pub use optional::{ConversationComplete, ConversationError};

--- a/src/protocol_types/multi_turn/request.rs
+++ b/src/protocol_types/multi_turn/request.rs
@@ -1,4 +1,6 @@
-use super::super::common::{TestCaseGroup, parse_test_case_group};
+use super::super::common::{
+    TestCaseGroup, TestResultIds, parse_test_case_group, parse_test_result_ids,
+};
 use serde::{Deserialize, Serialize};
 
 pub(crate) fn parse_threshold(value: &str) -> Result<f32, String> {
@@ -23,19 +25,6 @@ pub(crate) fn parse_even_turn_count(value: &str) -> Result<usize, String> {
     } else {
         Err(format!(
             "invalid max_turns '{value}': expected an even integer between 2 and 20",
-        ))
-    }
-}
-
-pub(crate) fn parse_test_result_id(value: &str) -> Result<i64, String> {
-    let parsed: i64 = value
-        .parse()
-        .map_err(|_| format!("invalid test_result_id '{value}': expected an integer >= 1"))?;
-    if parsed >= 1 {
-        Ok(parsed)
-    } else {
-        Err(format!(
-            "invalid test_result_id '{value}': expected an integer >= 1",
         ))
     }
 }
@@ -71,9 +60,9 @@ pub struct MultiTurnRerunEvalRequest {
         allow_hyphen_values = true
     )]
     pub max_turns: usize,
-    /// Historic test result ID to re-run
-    #[arg(long, value_parser = parse_test_result_id)]
-    pub test_result_id: i64,
+    /// Comma-separated historic test result IDs to re-run
+    #[arg(long, value_parser = parse_test_result_ids, allow_hyphen_values = true)]
+    pub test_result_ids: TestResultIds,
 }
 
 /// Payload for `MultiTurnRequestEnvelope` messages (Client -> Server).
@@ -89,7 +78,7 @@ pub struct MultiTurnRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MultiTurnRerunRequest {
-    pub test_result_id: i64,
+    pub test_result_ids: Vec<i64>,
     pub threshold: f32,
     pub max_turns: usize,
 }
@@ -115,10 +104,10 @@ impl MultiTurnEvaluationRequest {
         }
     }
 
-    pub fn test_result_id(&self) -> Option<i64> {
+    pub fn test_result_ids(&self) -> Option<&[i64]> {
         match self {
             MultiTurnEvaluationRequest::Standard(_) => None,
-            MultiTurnEvaluationRequest::Rerun(request) => Some(request.test_result_id),
+            MultiTurnEvaluationRequest::Rerun(request) => Some(&request.test_result_ids),
         }
     }
 }
@@ -136,7 +125,7 @@ impl From<MultiTurnEvalRequest> for MultiTurnEvaluationRequest {
 impl From<MultiTurnRerunEvalRequest> for MultiTurnEvaluationRequest {
     fn from(request: MultiTurnRerunEvalRequest) -> Self {
         MultiTurnEvaluationRequest::Rerun(MultiTurnRerunRequest {
-            test_result_id: request.test_result_id,
+            test_result_ids: request.test_result_ids.into(),
             threshold: request.threshold,
             max_turns: request.max_turns,
         })
@@ -221,7 +210,7 @@ mod tests {
     #[test]
     fn multi_turn_rerun_request_envelope_serializes_to_protocol_shape() {
         let envelope = MultiTurnRerunRequestEnvelope::from(MultiTurnRerunRequest {
-            test_result_id: 42,
+            test_result_ids: vec![42, 43],
             threshold: 0.5,
             max_turns: 6,
         });
@@ -234,7 +223,7 @@ mod tests {
                 "version": crate::consts::version::PROTOCOL_VERSION,
                 "type": "multi_turn_rerun_request",
                 "data": {
-                    "test_result_id": 42,
+                    "test_result_ids": [42, 43],
                     "threshold": 0.5,
                     "max_turns": 6
                 }

--- a/src/protocol_types/single_turn/request.rs
+++ b/src/protocol_types/single_turn/request.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use super::super::common::{TestCaseGroup, parse_test_case_group};
+use super::super::common::{
+    TestCaseGroup, TestResultIds, parse_test_case_group, parse_test_result_ids,
+};
 
 pub(crate) fn parse_threshold(value: &str) -> Result<f32, String> {
     let threshold: f32 = value
@@ -37,19 +39,6 @@ pub(crate) fn parse_maximum_iteration_layers(value: &str) -> Result<i32, String>
     } else {
         Err(format!(
             "invalid maximum_iteration_layers '{value}': expected an integer between 0 and 2",
-        ))
-    }
-}
-
-pub(crate) fn parse_test_result_id(value: &str) -> Result<i64, String> {
-    let parsed: i64 = value
-        .parse()
-        .map_err(|_| format!("invalid test_result_id '{value}': expected an integer >= 1"))?;
-    if parsed >= 1 {
-        Ok(parsed)
-    } else {
-        Err(format!(
-            "invalid test_result_id '{value}': expected an integer >= 1",
         ))
     }
 }
@@ -91,9 +80,9 @@ pub struct SingleTurnRerunEvalRequest {
         allow_hyphen_values = true
     )]
     pub maximum_iteration_layers: i32,
-    /// Historic test result ID to re-run
-    #[arg(long, value_parser = parse_test_result_id)]
-    pub test_result_id: i64,
+    /// Comma-separated historic test result IDs to re-run
+    #[arg(long, value_parser = parse_test_result_ids, allow_hyphen_values = true)]
+    pub test_result_ids: TestResultIds,
 }
 
 /// Payload for `SingleTurnRequestEnvelope` messages (Client -> Server).
@@ -111,7 +100,7 @@ pub struct SingleTurnRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SingleTurnRerunRequest {
-    pub test_result_id: i64,
+    pub test_result_ids: Vec<i64>,
     pub threshold: f32,
     pub variations: i32,
     pub maximum_iteration_layers: i32,
@@ -138,10 +127,10 @@ impl SingleTurnEvaluationRequest {
         }
     }
 
-    pub fn test_result_id(&self) -> Option<i64> {
+    pub fn test_result_ids(&self) -> Option<&[i64]> {
         match self {
             SingleTurnEvaluationRequest::Standard(_) => None,
-            SingleTurnEvaluationRequest::Rerun(request) => Some(request.test_result_id),
+            SingleTurnEvaluationRequest::Rerun(request) => Some(&request.test_result_ids),
         }
     }
 }
@@ -160,7 +149,7 @@ impl From<SingleTurnEvalRequest> for SingleTurnEvaluationRequest {
 impl From<SingleTurnRerunEvalRequest> for SingleTurnEvaluationRequest {
     fn from(request: SingleTurnRerunEvalRequest) -> Self {
         SingleTurnEvaluationRequest::Rerun(SingleTurnRerunRequest {
-            test_result_id: request.test_result_id,
+            test_result_ids: request.test_result_ids.into(),
             threshold: request.threshold,
             variations: request.variations,
             maximum_iteration_layers: request.maximum_iteration_layers,
@@ -248,7 +237,7 @@ mod tests {
     #[test]
     fn single_turn_rerun_request_envelope_serializes_to_protocol_shape() {
         let envelope = SingleTurnRerunRequestEnvelope::from(SingleTurnRerunRequest {
-            test_result_id: 42,
+            test_result_ids: vec![42, 43],
             threshold: 0.5,
             variations: 3,
             maximum_iteration_layers: 2,
@@ -262,7 +251,7 @@ mod tests {
                 "version": crate::consts::version::PROTOCOL_VERSION,
                 "type": "single_turn_rerun_request",
                 "data": {
-                    "test_result_id": 42,
+                    "test_result_ids": [42, 43],
                     "threshold": 0.5,
                     "variations": 3,
                     "maximum_iteration_layers": 2


### PR DESCRIPTION
Key change is from `--test-result-id` to `--test-result-ids` which accepts a comma separated integer list as opposed to a single integer.
