### PR TITLE
adds batch rerun by evaluation id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "circuit-breaker-labs"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circuit-breaker-labs"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 build = "build.rs"
 description = "Circuit Breaker Labs command-line interface"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -722,7 +722,15 @@ mod tests {
             Some(super::Command::Eval { evaluation }) => match evaluation {
                 super::EvaluationCommand::ReRun { rerun } => match rerun {
                     super::ReRunEvaluationCommand::SingleTurn { request, .. } => {
-                        assert_eq!(request.test_result_ids.as_slice(), &[42, 43]);
+                        assert_eq!(
+                            request
+                                .test_result_ids
+                                .as_ref()
+                                .expect("test result IDs should be set")
+                                .as_slice(),
+                            &[42, 43],
+                        );
+                        assert_eq!(request.evaluation_id, None);
                         assert!((request.threshold - 0.5).abs() < f32::EPSILON);
                         assert_eq!(request.variations, 2);
                         assert_eq!(request.maximum_iteration_layers, 1);
@@ -803,7 +811,106 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_multi_turn_test_case_groups() {
+    fn parses_valid_single_turn_rerun_command_with_evaluation_id() {
+        let args = Args::try_parse_from([
+            "cbl",
+            "--cbl-api-key",
+            "cbl-key",
+            "eval",
+            "re-run",
+            "single-turn",
+            "--threshold",
+            "0.5",
+            "--variations",
+            "2",
+            "--maximum-iteration-layers",
+            "1",
+            "--evaluation-id",
+            "123",
+            "openai",
+            "--api-key",
+            "openai-key",
+            "--model",
+            "gpt-4.1-nano",
+        ])
+        .expect("single-turn rerun args should parse");
+
+        match args.command {
+            Some(super::Command::Eval { evaluation }) => match evaluation {
+                super::EvaluationCommand::ReRun { rerun } => match rerun {
+                    super::ReRunEvaluationCommand::SingleTurn { request, .. } => {
+                        assert!(request.test_result_ids.is_none());
+                        assert_eq!(request.evaluation_id, Some(123));
+                    }
+                    super::ReRunEvaluationCommand::MultiTurn { .. } => {
+                        panic!("expected single-turn rerun command")
+                    }
+                },
+                super::EvaluationCommand::SingleTurn { .. }
+                | super::EvaluationCommand::MultiTurn { .. } => panic!("expected rerun command"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn rejects_single_turn_rerun_without_selector() {
+        let err = Args::try_parse_from([
+            "cbl",
+            "--cbl-api-key",
+            "cbl-key",
+            "eval",
+            "re-run",
+            "single-turn",
+            "--threshold",
+            "0.5",
+            "--variations",
+            "2",
+            "--maximum-iteration-layers",
+            "1",
+            "openai",
+            "--api-key",
+            "openai-key",
+            "--model",
+            "gpt-4.1-nano",
+        ])
+        .expect_err("missing rerun selector should be rejected");
+
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn rejects_single_turn_rerun_with_multiple_selectors() {
+        let err = Args::try_parse_from([
+            "cbl",
+            "--cbl-api-key",
+            "cbl-key",
+            "eval",
+            "re-run",
+            "single-turn",
+            "--threshold",
+            "0.5",
+            "--variations",
+            "2",
+            "--maximum-iteration-layers",
+            "1",
+            "--test-result-ids",
+            "42",
+            "--evaluation-id",
+            "123",
+            "openai",
+            "--api-key",
+            "openai-key",
+            "--model",
+            "gpt-4.1-nano",
+        ])
+        .expect_err("multiple rerun selectors should be rejected");
+
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn rejects_multi_turn_rerun_without_selector() {
         let err = Args::try_parse_from([
             "cbl",
             "--cbl-api-key",
@@ -821,7 +928,7 @@ mod tests {
             "--model",
             "gpt-4.1-nano",
         ])
-        .expect_err("missing test case groups should be rejected");
+        .expect_err("missing rerun selector should be rejected");
 
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
@@ -853,7 +960,15 @@ mod tests {
             Some(super::Command::Eval { evaluation }) => match evaluation {
                 super::EvaluationCommand::ReRun { rerun } => match rerun {
                     super::ReRunEvaluationCommand::MultiTurn { request, .. } => {
-                        assert_eq!(request.test_result_ids.as_slice(), &[42, 43]);
+                        assert_eq!(
+                            request
+                                .test_result_ids
+                                .as_ref()
+                                .expect("test result IDs should be set")
+                                .as_slice(),
+                            &[42, 43],
+                        );
+                        assert_eq!(request.evaluation_id, None);
                         assert!((request.threshold - 0.5).abs() < f32::EPSILON);
                         assert_eq!(request.max_turns, 4);
                     }
@@ -866,6 +981,75 @@ mod tests {
             },
             _ => panic!("expected eval command"),
         }
+    }
+
+    #[test]
+    fn parses_valid_multi_turn_rerun_command_with_evaluation_id() {
+        let args = Args::try_parse_from([
+            "cbl",
+            "--cbl-api-key",
+            "cbl-key",
+            "eval",
+            "re-run",
+            "multi-turn",
+            "--threshold",
+            "0.5",
+            "--max-turns",
+            "4",
+            "--evaluation-id",
+            "123",
+            "openai",
+            "--api-key",
+            "openai-key",
+            "--model",
+            "gpt-4.1-nano",
+        ])
+        .expect("multi-turn rerun args should parse");
+
+        match args.command {
+            Some(super::Command::Eval { evaluation }) => match evaluation {
+                super::EvaluationCommand::ReRun { rerun } => match rerun {
+                    super::ReRunEvaluationCommand::MultiTurn { request, .. } => {
+                        assert!(request.test_result_ids.is_none());
+                        assert_eq!(request.evaluation_id, Some(123));
+                    }
+                    super::ReRunEvaluationCommand::SingleTurn { .. } => {
+                        panic!("expected multi-turn rerun command")
+                    }
+                },
+                super::EvaluationCommand::SingleTurn { .. }
+                | super::EvaluationCommand::MultiTurn { .. } => panic!("expected rerun command"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn rejects_multi_turn_rerun_with_multiple_selectors() {
+        let err = Args::try_parse_from([
+            "cbl",
+            "--cbl-api-key",
+            "cbl-key",
+            "eval",
+            "re-run",
+            "multi-turn",
+            "--threshold",
+            "0.5",
+            "--max-turns",
+            "4",
+            "--test-result-ids",
+            "42",
+            "--evaluation-id",
+            "123",
+            "openai",
+            "--api-key",
+            "openai-key",
+            "--model",
+            "gpt-4.1-nano",
+        ])
+        .expect_err("multiple rerun selectors should be rejected");
+
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/src/consts/version.rs
+++ b/src/consts/version.rs
@@ -1,1 +1,1 @@
-pub const PROTOCOL_VERSION: &str = "1.0.9";
+pub const PROTOCOL_VERSION: &str = "1.0.10";

--- a/src/evaluation_output.rs
+++ b/src/evaluation_output.rs
@@ -1,4 +1,4 @@
-use crate::protocol_types::common::TestCaseGroup;
+use crate::protocol_types::common::{RerunSelector, TestCaseGroup};
 
 #[derive(serde::Serialize)]
 struct EvaluationOutput<'a, T>
@@ -30,25 +30,40 @@ where
 {
     #[serde(flatten)]
     result: &'a T,
-    test_result_ids: &'a [i64],
+    #[serde(flatten)]
+    source: RerunEvaluationSource<'a>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum RerunEvaluationSource<'a> {
+    TestResultIds { test_result_ids: &'a [i64] },
+    SourceEvaluationId { source_evaluation_id: i64 },
 }
 
 pub fn serialize_rerun_evaluation_output<T>(
     result: &T,
-    test_result_ids: &[i64],
+    selector: &RerunSelector,
 ) -> Result<String, serde_json::Error>
 where
     T: serde::Serialize,
 {
-    serde_json::to_string_pretty(&RerunEvaluationOutput {
-        result,
-        test_result_ids,
-    })
+    let source = match selector {
+        RerunSelector::TestResultIds { test_result_ids } => {
+            RerunEvaluationSource::TestResultIds { test_result_ids }
+        }
+        RerunSelector::EvaluationId { evaluation_id } => {
+            RerunEvaluationSource::SourceEvaluationId {
+                source_evaluation_id: *evaluation_id,
+            }
+        }
+    };
+    serde_json::to_string_pretty(&RerunEvaluationOutput { result, source })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{serialize_evaluation_output, serialize_rerun_evaluation_output};
+    use super::{RerunSelector, serialize_evaluation_output, serialize_rerun_evaluation_output};
     use serde::Serialize;
     use serde_json::json;
 
@@ -93,8 +108,13 @@ mod tests {
             total_failed: 1,
         };
 
-        let json = serialize_rerun_evaluation_output(&result, &[42, 43])
-            .expect("rerun evaluation output should serialize");
+        let json = serialize_rerun_evaluation_output(
+            &result,
+            &RerunSelector::TestResultIds {
+                test_result_ids: vec![42, 43],
+            },
+        )
+        .expect("rerun evaluation output should serialize");
         let value: serde_json::Value =
             serde_json::from_str(&json).expect("evaluation output should be valid json");
 
@@ -104,6 +124,31 @@ mod tests {
                 "total_passed": 3,
                 "total_failed": 1,
                 "test_result_ids": [42, 43]
+            })
+        );
+    }
+
+    #[test]
+    fn rerun_evaluation_output_includes_source_evaluation_id() {
+        let result = TestResult {
+            total_passed: 3,
+            total_failed: 1,
+        };
+
+        let json = serialize_rerun_evaluation_output(
+            &result,
+            &RerunSelector::EvaluationId { evaluation_id: 123 },
+        )
+        .expect("rerun evaluation output should serialize");
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("evaluation output should be valid json");
+
+        assert_eq!(
+            value,
+            json!({
+                "total_passed": 3,
+                "total_failed": 1,
+                "source_evaluation_id": 123
             })
         );
     }

--- a/src/evaluations/multiturn.rs
+++ b/src/evaluations/multiturn.rs
@@ -303,6 +303,7 @@ mod tests {
                 json!({
                     "type": "multi_turn_response",
                     "data": {
+                        "evaluation_id": 21,
                         "total_passed": 1,
                         "total_failed": 0,
                         "failed_results": []
@@ -332,6 +333,7 @@ mod tests {
 
         assert_eq!(response.total_passed, 1);
         assert_eq!(response.total_failed, 0);
+        assert_eq!(response.evaluation_id, 21);
         assert!(response.failed_results.is_empty());
     }
 
@@ -351,6 +353,7 @@ mod tests {
                 json!({
                     "type": "multi_turn_response",
                     "data": {
+                        "evaluation_id": 22,
                         "total_passed": 1,
                         "total_failed": 0,
                         "failed_results": []
@@ -380,6 +383,7 @@ mod tests {
 
         assert_eq!(response.total_passed, 1);
         assert_eq!(response.total_failed, 0);
+        assert_eq!(response.evaluation_id, 22);
     }
 
     #[tokio::test]
@@ -407,6 +411,7 @@ mod tests {
                 json!({
                     "type": "multi_turn_response",
                     "data": {
+                        "evaluation_id": 23,
                         "total_passed": 1,
                         "total_failed": 0,
                         "failed_results": []
@@ -436,5 +441,6 @@ mod tests {
 
         assert_eq!(response.total_passed, 1);
         assert_eq!(response.total_failed, 0);
+        assert_eq!(response.evaluation_id, 23);
     }
 }

--- a/src/evaluations/multiturn.rs
+++ b/src/evaluations/multiturn.rs
@@ -368,7 +368,9 @@ mod tests {
             websocket,
             provider,
             MultiTurnEvaluationRequest::Rerun(MultiTurnRerunRequest {
-                test_result_ids: vec![42, 43],
+                selector: crate::protocol_types::common::RerunSelector::TestResultIds {
+                    test_result_ids: vec![42, 43],
+                },
                 threshold: 0.5,
                 max_turns: 4,
             }),

--- a/src/evaluations/singleturn.rs
+++ b/src/evaluations/singleturn.rs
@@ -316,6 +316,7 @@ mod tests {
                     json!({
                         "type": "single_turn_response",
                         "data": {
+                            "evaluation_id": 11,
                             "total_passed": 2,
                             "total_failed": 0,
                             "failed_results": []
@@ -346,6 +347,7 @@ mod tests {
 
         assert_eq!(response.total_passed, 2);
         assert_eq!(response.total_failed, 0);
+        assert_eq!(response.evaluation_id, 11);
         assert!(response.failed_results.is_empty());
     }
 
@@ -365,6 +367,7 @@ mod tests {
                 json!({
                     "type": "single_turn_response",
                     "data": {
+                        "evaluation_id": 12,
                         "total_passed": 1,
                         "total_failed": 0,
                         "failed_results": []
@@ -395,6 +398,7 @@ mod tests {
 
         assert_eq!(response.total_passed, 1);
         assert_eq!(response.total_failed, 0);
+        assert_eq!(response.evaluation_id, 12);
     }
 
     #[tokio::test]
@@ -489,6 +493,7 @@ mod tests {
                 json!({
                     "type": "single_turn_response",
                     "data": {
+                        "evaluation_id": 13,
                         "total_passed": 0,
                         "total_failed": 1,
                         "failed_results": []
@@ -519,6 +524,7 @@ mod tests {
 
         assert_eq!(response.total_passed, 0);
         assert_eq!(response.total_failed, 1);
+        assert_eq!(response.evaluation_id, 13);
     }
 
     #[tokio::test]

--- a/src/evaluations/singleturn.rs
+++ b/src/evaluations/singleturn.rs
@@ -382,7 +382,9 @@ mod tests {
             websocket,
             provider,
             SingleTurnEvaluationRequest::Rerun(SingleTurnRerunRequest {
-                test_result_ids: vec![42, 43],
+                selector: crate::protocol_types::common::RerunSelector::TestResultIds {
+                    test_result_ids: vec![42, 43],
+                },
                 threshold: 0.5,
                 variations: 2,
                 maximum_iteration_layers: 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ async fn run_single_turn_evaluation(
     output_file: Option<PathBuf>,
 ) -> Result<(), RunEvaluationError> {
     let test_case_groups = request.test_case_groups().map(<[_]>::to_vec);
-    let test_result_ids = request.test_result_ids().map(<[_]>::to_vec);
+    let rerun_selector = request.rerun_selector();
     let maximum_iteration_layers = request.maximum_iteration_layers();
     let result = if log_mode {
         evaluations::singleturn::run_evaluation(websocket, provider, request, None).await?
@@ -176,8 +176,8 @@ async fn run_single_turn_evaluation(
         ))
     });
 
-    let json = if let Some(test_result_ids) = test_result_ids {
-        serialize_rerun_evaluation_output(&result, &test_result_ids)?
+    let json = if let Some(rerun_selector) = rerun_selector {
+        serialize_rerun_evaluation_output(&result, &rerun_selector)?
     } else {
         serialize_evaluation_output(
             &result,
@@ -200,7 +200,7 @@ async fn run_multi_turn_evaluation(
     output_file: Option<PathBuf>,
 ) -> Result<(), RunEvaluationError> {
     let test_case_groups = request.test_case_groups().map(<[_]>::to_vec);
-    let test_result_ids = request.test_result_ids().map(<[_]>::to_vec);
+    let rerun_selector = request.rerun_selector();
     let result = if log_mode {
         evaluations::multiturn::run_evaluation(websocket, provider, request, None).await?
     } else {
@@ -221,8 +221,8 @@ async fn run_multi_turn_evaluation(
         ))
     });
 
-    let json = if let Some(test_result_ids) = test_result_ids {
-        serialize_rerun_evaluation_output(&result, &test_result_ids)?
+    let json = if let Some(rerun_selector) = rerun_selector {
+        serialize_rerun_evaluation_output(&result, &rerun_selector)?
     } else {
         serialize_evaluation_output(
             &result,

--- a/src/protocol_types/common/common.rs
+++ b/src/protocol_types/common/common.rs
@@ -6,6 +6,8 @@ pub type ConversationId = i32;
 /// Test case group identifier
 pub type TestCaseGroup = String;
 
+pub type EvaluationId = i64;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TestResultIds(Vec<i64>);
 
@@ -21,6 +23,28 @@ impl Into<Vec<i64>> for TestResultIds {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RerunSelector {
+    TestResultIds { test_result_ids: Vec<i64> },
+    EvaluationId { evaluation_id: EvaluationId },
+}
+
+impl RerunSelector {
+    pub fn from_parts(
+        test_result_ids: Option<TestResultIds>,
+        evaluation_id: Option<EvaluationId>,
+    ) -> Self {
+        match (test_result_ids, evaluation_id) {
+            (Some(test_result_ids), None) => RerunSelector::TestResultIds {
+                test_result_ids: test_result_ids.into(),
+            },
+            (None, Some(evaluation_id)) => RerunSelector::EvaluationId { evaluation_id },
+            _ => unreachable!("clap requires exactly one rerun selector"),
+        }
+    }
+}
+
 pub fn parse_test_case_group(value: &str) -> Result<TestCaseGroup, String> {
     let value = value.trim();
     if value.is_empty() {
@@ -30,6 +54,18 @@ pub fn parse_test_case_group(value: &str) -> Result<TestCaseGroup, String> {
     }
 
     Ok(value.to_string())
+}
+
+pub fn parse_evaluation_id(value: &str) -> Result<EvaluationId, String> {
+    let parsed: EvaluationId = value
+        .parse()
+        .map_err(|_| format!("invalid evaluation_id '{value}': expected an integer >= 1"))?;
+    if parsed < 1 {
+        return Err(format!(
+            "invalid evaluation_id '{value}': expected an integer >= 1",
+        ));
+    }
+    Ok(parsed)
 }
 
 pub fn parse_test_result_ids(value: &str) -> Result<TestResultIds, String> {
@@ -143,7 +179,7 @@ impl From<CompletionResponse> for CompletionResponseEnvelope {
 mod tests {
     use super::{
         CompletionRequestEnvelope, CompletionResponse, CompletionResponseEnvelope, TestCaseGroup,
-        TestResultIds, parse_test_case_group, parse_test_result_ids,
+        TestResultIds, parse_evaluation_id, parse_test_case_group, parse_test_result_ids,
     };
     use serde_json::json;
 
@@ -226,6 +262,15 @@ mod tests {
                 parse_test_result_ids(value).expect_err("invalid test result IDs should fail");
             assert!(error.contains("test_result_ids"));
             assert!(error.contains("comma-separated integers >= 1"));
+        }
+    }
+
+    #[test]
+    fn invalid_evaluation_ids_are_rejected() {
+        for value in ["", "0", "-1", "abc"] {
+            let error = parse_evaluation_id(value).expect_err("invalid evaluation ID should fail");
+            assert!(error.contains("evaluation_id"));
+            assert!(error.contains("integer >= 1"));
         }
     }
 }

--- a/src/protocol_types/common/mod.rs
+++ b/src/protocol_types/common/mod.rs
@@ -4,8 +4,9 @@ mod errors;
 mod optional;
 
 pub use common::{
-    CompletionRequest, CompletionResponse, CompletionResponseEnvelope, ConversationId, Message,
-    Role, TestCaseGroup, TestResultIds, parse_test_case_group, parse_test_result_ids,
+    CompletionRequest, CompletionResponse, CompletionResponseEnvelope, ConversationId,
+    EvaluationId, Message, RerunSelector, Role, TestCaseGroup, TestResultIds, parse_evaluation_id,
+    parse_test_case_group, parse_test_result_ids,
 };
 pub use errors::{CompletionError, CompletionErrorEnvelope, ServerErrorCode};
 pub use optional::{ConversationComplete, ConversationError};

--- a/src/protocol_types/multi_turn/mod.rs
+++ b/src/protocol_types/multi_turn/mod.rs
@@ -109,6 +109,7 @@ mod tests {
         let payload = json!({
             "type": "multi_turn_response",
             "data": {
+                "evaluation_id": 202,
                 "total_passed": 2,
                 "total_failed": 1,
                 "failed_results": [
@@ -129,6 +130,7 @@ mod tests {
 
         match message {
             MultiTurnReceivableMessage::MultiTurnResponse(resp) => {
+                assert_eq!(resp.evaluation_id, 202);
                 assert_eq!(resp.total_passed, 2);
                 assert_eq!(resp.total_failed, 1);
                 assert_eq!(resp.failed_results.len(), 1);

--- a/src/protocol_types/multi_turn/request.rs
+++ b/src/protocol_types/multi_turn/request.rs
@@ -1,5 +1,6 @@
 use super::super::common::{
-    TestCaseGroup, TestResultIds, parse_test_case_group, parse_test_result_ids,
+    EvaluationId, RerunSelector, TestCaseGroup, TestResultIds, parse_evaluation_id,
+    parse_test_case_group, parse_test_result_ids,
 };
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +49,12 @@ pub struct MultiTurnEvalRequest {
 }
 
 #[derive(Debug, Clone, clap::Args)]
+#[command(group(
+    clap::ArgGroup::new("rerun_selector")
+        .required(true)
+        .multiple(false)
+        .args(["test_result_ids", "evaluation_id"])
+))]
 pub struct MultiTurnRerunEvalRequest {
     /// Responses below this safety score threshold will fail
     #[arg(short, long, value_parser = parse_threshold, allow_hyphen_values = true)]
@@ -61,8 +68,16 @@ pub struct MultiTurnRerunEvalRequest {
     )]
     pub max_turns: usize,
     /// Comma-separated historic test result IDs to re-run
-    #[arg(long, value_parser = parse_test_result_ids, allow_hyphen_values = true)]
-    pub test_result_ids: TestResultIds,
+    #[arg(
+        long = "test-result-ids",
+        alias = "test-result-id",
+        value_parser = parse_test_result_ids,
+        allow_hyphen_values = true
+    )]
+    pub test_result_ids: Option<TestResultIds>,
+    /// Historic evaluation ID whose stored results should be re-run
+    #[arg(long, value_parser = parse_evaluation_id, allow_hyphen_values = true)]
+    pub evaluation_id: Option<EvaluationId>,
 }
 
 /// Payload for `MultiTurnRequestEnvelope` messages (Client -> Server).
@@ -78,7 +93,8 @@ pub struct MultiTurnRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MultiTurnRerunRequest {
-    pub test_result_ids: Vec<i64>,
+    #[serde(flatten)]
+    pub selector: RerunSelector,
     pub threshold: f32,
     pub max_turns: usize,
 }
@@ -107,7 +123,17 @@ impl MultiTurnEvaluationRequest {
     pub fn test_result_ids(&self) -> Option<&[i64]> {
         match self {
             MultiTurnEvaluationRequest::Standard(_) => None,
-            MultiTurnEvaluationRequest::Rerun(request) => Some(&request.test_result_ids),
+            MultiTurnEvaluationRequest::Rerun(request) => match &request.selector {
+                RerunSelector::TestResultIds { test_result_ids } => Some(test_result_ids),
+                RerunSelector::EvaluationId { .. } => None,
+            },
+        }
+    }
+
+    pub fn rerun_selector(&self) -> Option<RerunSelector> {
+        match self {
+            MultiTurnEvaluationRequest::Standard(_) => None,
+            MultiTurnEvaluationRequest::Rerun(request) => Some(request.selector.clone()),
         }
     }
 }
@@ -125,7 +151,7 @@ impl From<MultiTurnEvalRequest> for MultiTurnEvaluationRequest {
 impl From<MultiTurnRerunEvalRequest> for MultiTurnEvaluationRequest {
     fn from(request: MultiTurnRerunEvalRequest) -> Self {
         MultiTurnEvaluationRequest::Rerun(MultiTurnRerunRequest {
-            test_result_ids: request.test_result_ids.into(),
+            selector: RerunSelector::from_parts(request.test_result_ids, request.evaluation_id),
             threshold: request.threshold,
             max_turns: request.max_turns,
         })
@@ -210,7 +236,9 @@ mod tests {
     #[test]
     fn multi_turn_rerun_request_envelope_serializes_to_protocol_shape() {
         let envelope = MultiTurnRerunRequestEnvelope::from(MultiTurnRerunRequest {
-            test_result_ids: vec![42, 43],
+            selector: crate::protocol_types::common::RerunSelector::TestResultIds {
+                test_result_ids: vec![42, 43],
+            },
             threshold: 0.5,
             max_turns: 6,
         });
@@ -224,6 +252,32 @@ mod tests {
                 "type": "multi_turn_rerun_request",
                 "data": {
                     "test_result_ids": [42, 43],
+                    "threshold": 0.5,
+                    "max_turns": 6
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn multi_turn_rerun_request_envelope_serializes_evaluation_id() {
+        let envelope = MultiTurnRerunRequestEnvelope::from(MultiTurnRerunRequest {
+            selector: crate::protocol_types::common::RerunSelector::EvaluationId {
+                evaluation_id: 123,
+            },
+            threshold: 0.5,
+            max_turns: 6,
+        });
+
+        let value = serde_json::to_value(envelope).expect("envelope should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "version": crate::consts::version::PROTOCOL_VERSION,
+                "type": "multi_turn_rerun_request",
+                "data": {
+                    "evaluation_id": 123,
                     "threshold": 0.5,
                     "max_turns": 6
                 }

--- a/src/protocol_types/multi_turn/response.rs
+++ b/src/protocol_types/multi_turn/response.rs
@@ -18,6 +18,8 @@ pub struct FailedMultiTurnResult {
 /// Payload for `MultiTurnResponseEnvelope` messages (Server -> Client).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MultiTurnResponse {
+    /// Persisted evaluation run ID.
+    pub evaluation_id: i64,
     /// Number of conversations that passed
     pub total_passed: i32,
     /// Number of conversations that failed
@@ -58,6 +60,7 @@ mod tests {
         let value = json!({
             "type": "multi_turn_response",
             "data": {
+                "evaluation_id": 202,
                 "total_passed": 3,
                 "total_failed": 1,
                 "failed_results": [
@@ -79,6 +82,7 @@ mod tests {
             serde_json::from_value(value).expect("response envelope should deserialize");
 
         assert_eq!(envelope.message_type, "multi_turn_response");
+        assert_eq!(envelope.data.evaluation_id, 202);
         assert_eq!(envelope.data.total_passed, 3);
         assert_eq!(envelope.data.total_failed, 1);
         assert_eq!(envelope.data.failed_results.len(), 1);

--- a/src/protocol_types/single_turn/request.rs
+++ b/src/protocol_types/single_turn/request.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::super::common::{
-    TestCaseGroup, TestResultIds, parse_test_case_group, parse_test_result_ids,
+    EvaluationId, RerunSelector, TestCaseGroup, TestResultIds, parse_evaluation_id,
+    parse_test_case_group, parse_test_result_ids,
 };
 
 pub(crate) fn parse_threshold(value: &str) -> Result<f32, String> {
@@ -65,6 +66,12 @@ pub struct SingleTurnEvalRequest {
 }
 
 #[derive(Debug, Clone, clap::Args)]
+#[command(group(
+    clap::ArgGroup::new("rerun_selector")
+        .required(true)
+        .multiple(false)
+        .args(["test_result_ids", "evaluation_id"])
+))]
 pub struct SingleTurnRerunEvalRequest {
     /// Responses below this safety score threshold will fail
     #[arg(short, long, value_parser = parse_threshold, allow_hyphen_values = true)]
@@ -81,8 +88,16 @@ pub struct SingleTurnRerunEvalRequest {
     )]
     pub maximum_iteration_layers: i32,
     /// Comma-separated historic test result IDs to re-run
-    #[arg(long, value_parser = parse_test_result_ids, allow_hyphen_values = true)]
-    pub test_result_ids: TestResultIds,
+    #[arg(
+        long = "test-result-ids",
+        alias = "test-result-id",
+        value_parser = parse_test_result_ids,
+        allow_hyphen_values = true
+    )]
+    pub test_result_ids: Option<TestResultIds>,
+    /// Historic evaluation ID whose stored results should be re-run
+    #[arg(long, value_parser = parse_evaluation_id, allow_hyphen_values = true)]
+    pub evaluation_id: Option<EvaluationId>,
 }
 
 /// Payload for `SingleTurnRequestEnvelope` messages (Client -> Server).
@@ -100,7 +115,8 @@ pub struct SingleTurnRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SingleTurnRerunRequest {
-    pub test_result_ids: Vec<i64>,
+    #[serde(flatten)]
+    pub selector: RerunSelector,
     pub threshold: f32,
     pub variations: i32,
     pub maximum_iteration_layers: i32,
@@ -130,7 +146,17 @@ impl SingleTurnEvaluationRequest {
     pub fn test_result_ids(&self) -> Option<&[i64]> {
         match self {
             SingleTurnEvaluationRequest::Standard(_) => None,
-            SingleTurnEvaluationRequest::Rerun(request) => Some(&request.test_result_ids),
+            SingleTurnEvaluationRequest::Rerun(request) => match &request.selector {
+                RerunSelector::TestResultIds { test_result_ids } => Some(test_result_ids),
+                RerunSelector::EvaluationId { .. } => None,
+            },
+        }
+    }
+
+    pub fn rerun_selector(&self) -> Option<RerunSelector> {
+        match self {
+            SingleTurnEvaluationRequest::Standard(_) => None,
+            SingleTurnEvaluationRequest::Rerun(request) => Some(request.selector.clone()),
         }
     }
 }
@@ -149,7 +175,7 @@ impl From<SingleTurnEvalRequest> for SingleTurnEvaluationRequest {
 impl From<SingleTurnRerunEvalRequest> for SingleTurnEvaluationRequest {
     fn from(request: SingleTurnRerunEvalRequest) -> Self {
         SingleTurnEvaluationRequest::Rerun(SingleTurnRerunRequest {
-            test_result_ids: request.test_result_ids.into(),
+            selector: RerunSelector::from_parts(request.test_result_ids, request.evaluation_id),
             threshold: request.threshold,
             variations: request.variations,
             maximum_iteration_layers: request.maximum_iteration_layers,
@@ -237,7 +263,9 @@ mod tests {
     #[test]
     fn single_turn_rerun_request_envelope_serializes_to_protocol_shape() {
         let envelope = SingleTurnRerunRequestEnvelope::from(SingleTurnRerunRequest {
-            test_result_ids: vec![42, 43],
+            selector: crate::protocol_types::common::RerunSelector::TestResultIds {
+                test_result_ids: vec![42, 43],
+            },
             threshold: 0.5,
             variations: 3,
             maximum_iteration_layers: 2,
@@ -252,6 +280,34 @@ mod tests {
                 "type": "single_turn_rerun_request",
                 "data": {
                     "test_result_ids": [42, 43],
+                    "threshold": 0.5,
+                    "variations": 3,
+                    "maximum_iteration_layers": 2
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn single_turn_rerun_request_envelope_serializes_evaluation_id() {
+        let envelope = SingleTurnRerunRequestEnvelope::from(SingleTurnRerunRequest {
+            selector: crate::protocol_types::common::RerunSelector::EvaluationId {
+                evaluation_id: 123,
+            },
+            threshold: 0.5,
+            variations: 3,
+            maximum_iteration_layers: 2,
+        });
+
+        let value = serde_json::to_value(envelope).expect("envelope should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "version": crate::consts::version::PROTOCOL_VERSION,
+                "type": "single_turn_rerun_request",
+                "data": {
+                    "evaluation_id": 123,
                     "threshold": 0.5,
                     "variations": 3,
                     "maximum_iteration_layers": 2

--- a/src/protocol_types/single_turn/response.rs
+++ b/src/protocol_types/single_turn/response.rs
@@ -20,6 +20,8 @@ pub struct FailedSingleTurnResult {
 /// Payload for `SingleTurnResponseEnvelope` messages (Server -> Client).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SingleTurnResponse {
+    /// Persisted evaluation run ID.
+    pub evaluation_id: i64,
     /// Number of test cases that passed
     pub total_passed: i32,
     /// Number of test cases that failed
@@ -61,6 +63,7 @@ mod tests {
         let value = json!({
             "type": "single_turn_response",
             "data": {
+                "evaluation_id": 101,
                 "total_passed": 5,
                 "total_failed": 1,
                 "failed_results": [
@@ -82,6 +85,7 @@ mod tests {
             serde_json::from_value(value).expect("response envelope should deserialize");
 
         assert_eq!(envelope.message_type, "single_turn_response");
+        assert_eq!(envelope.data.evaluation_id, 101);
         assert_eq!(envelope.data.total_passed, 5);
         assert_eq!(envelope.data.total_failed, 1);
         assert_eq!(envelope.data.failed_results.len(), 1);


### PR DESCRIPTION
Adds logging for evaluation id in outputted JSON, allows for a batch rerun of an entire test run through this evaluation id